### PR TITLE
Remove use of ioutil package

### DIFF
--- a/go-mux/mux_test.go
+++ b/go-mux/mux_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -2775,7 +2774,7 @@ func TestSubrouterCustomMethodNotAllowed(t *testing.T) {
 				tt.Errorf("Expected status code 405 (got %d)", w.Code)
 			}
 
-			b, err := ioutil.ReadAll(w.Body)
+			b, err := io.ReadAll(w.Body)
 			if err != nil {
 				tt.Errorf("failed to read body: %v", err)
 			}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)