### PR TITLE
Use errors.Is/errors.As instead of == comparisons against errors

### DIFF
--- a/go-mux/mux.go
+++ b/go-mux/mux.go
@@ -146,7 +146,7 @@ func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 		}
 	}
 
-	if match.MatchErr == ErrMethodMismatch {
+	if errors.Is(match.MatchErr, ErrMethodMismatch) {
 		if r.MethodNotAllowedHandler != nil {
 			match.Handler = r.MethodNotAllowedHandler
 			return true
@@ -199,7 +199,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		req = setCurrentRoute(req, match.Route)
 	}
 
-	if handler == nil && match.MatchErr == ErrMethodMismatch {
+	if handler == nil && errors.Is(match.MatchErr, ErrMethodMismatch) {
 		handler = methodNotAllowedHandler()
 	}
 
@@ -373,7 +373,7 @@ type WalkFunc func(route *Route, router *Router, ancestors []*Route) error
 func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 	for _, t := range r.routes {
 		err := walkFn(t, r, ancestors)
-		if err == SkipRouter {
+		if errors.Is(err, SkipRouter) {
 			continue
 		}
 		if err != nil {

--- a/go-mux/route.go
+++ b/go-mux/route.go
@@ -60,7 +60,7 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 			// run middleware. If not ignored, the middleware would see a
 			// non-nil MatchErr and be skipped, even when there was a
 			// matching route.
-			if match.MatchErr == ErrNotFound {
+			if errors.Is(match.MatchErr, ErrNotFound) {
 				match.MatchErr = nil
 			}
 
@@ -74,7 +74,7 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 		return false
 	}
 
-	if match.MatchErr == ErrMethodMismatch && r.handler != nil {
+	if errors.Is(match.MatchErr, ErrMethodMismatch) && r.handler != nil {
 		// We found a route which matches request method, clear MatchErr
 		match.MatchErr = nil
 		// Then override the mis-matched handler


### PR DESCRIPTION
This change replaces direct `==`/`!=` comparisons against error values with the
standard library helpers `errors.Is` (for sentinel error values) and `errors.As`
(for error types).

Direct comparison breaks when an error is wrapped (e.g. with `fmt.Errorf("...: %w", err)`),
whereas `errors.Is`/`errors.As` traverse the wrap chain.

Notes:
- Comparisons against `nil` are intentionally left unchanged.
- Test files, vendored code, and generated code were not modified.

[_Created by Sourcegraph batch change `bahrmichael/432ac474-d2a7-4950-b17f-2a1b1fe59e87`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/432ac474-d2a7-4950-b17f-2a1b1fe59e87)