### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/go-mux/.circleci/config.yml
+++ b/go-mux/.circleci/config.yml
@@ -47,32 +47,32 @@ jobs:
   "1.12":
     <<: *test
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.26.4
 
   "1.11":
     <<: *test
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.26.4
 
   "1.10":
     <<: *test
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.26.4
 
   "1.9":
     <<: *test
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.26.4
 
   "1.8":
     <<: *test
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.26.4
 
   "1.7":
     <<: *test
     docker:
-      - image: circleci/golang:1.7
+      - image: circleci/golang:1.26.4
 
 workflows:
   version: 2

--- a/go-mux/context.go
+++ b/go-mux/context.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 )
 
-func contextGet(r *http.Request, key interface{}) interface{} {
+func contextGet(r *http.Request, key any) any {
 	return r.Context().Value(key)
 }
 
-func contextSet(r *http.Request, key, val interface{}) *http.Request {
+func contextSet(r *http.Request, key, val any) *http.Request {
 	if val == nil {
 		return r
 	}

--- a/go-mux/go.mod
+++ b/go-mux/go.mod
@@ -1,3 +1,3 @@
 module github.com/gorilla/mux
 
-go 1.12
+go 1.26.4

--- a/go-mux/mux.go
+++ b/go-mux/mux.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"regexp"
+	"slices"
 )
 
 var (
@@ -30,17 +31,17 @@ func NewRouter() *Router {
 // It implements the http.Handler interface, so it can be registered to serve
 // requests:
 //
-//     var router = mux.NewRouter()
+//	var router = mux.NewRouter()
 //
-//     func main() {
-//         http.Handle("/", router)
-//     }
+//	func main() {
+//	    http.Handle("/", router)
+//	}
 //
 // Or, for Google App Engine, register it in a init() function:
 //
-//     func init() {
-//         http.Handle("/", router)
-//     }
+//	func init() {
+//	    http.Handle("/", router)
+//	}
 //
 // This will send all incoming requests to the router.
 type Router struct {
@@ -444,11 +445,11 @@ func CurrentRoute(r *http.Request) *Route {
 	return nil
 }
 
-func setVars(r *http.Request, val interface{}) *http.Request {
+func setVars(r *http.Request, val any) *http.Request {
 	return contextSet(r, varsKey, val)
 }
 
-func setCurrentRoute(r *http.Request, val interface{}) *http.Request {
+func setCurrentRoute(r *http.Request, val any) *http.Request {
 	return contextSet(r, routeKey, val)
 }
 
@@ -532,12 +533,7 @@ func mapFromPairsToRegex(pairs ...string) (map[string]*regexp.Regexp, error) {
 
 // matchInArray returns true if the given string value is in the array.
 func matchInArray(arr []string, value string) bool {
-	for _, v := range arr {
-		if v == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(arr, value)
 }
 
 // matchMapWithString returns true if the given key/value pairs exist in a given map.
@@ -552,13 +548,7 @@ func matchMapWithString(toCheck map[string]string, toMatch map[string][]string, 
 		} else if v != "" {
 			// If value was defined as an empty string we only check that the
 			// key exists. Otherwise we also check for equality.
-			valueExists := false
-			for _, value := range values {
-				if v == value {
-					valueExists = true
-					break
-				}
-			}
+			valueExists := slices.Contains(values, v)
 			if !valueExists {
 				return false
 			}
@@ -580,13 +570,7 @@ func matchMapWithRegex(toCheck map[string]*regexp.Regexp, toMatch map[string][]s
 		} else if v != nil {
 			// If value was defined as an empty string we only check that the
 			// key exists. Otherwise we also check for equality.
-			valueExists := false
-			for _, value := range values {
-				if v.MatchString(value) {
-					valueExists = true
-					break
-				}
-			}
+			valueExists := slices.ContainsFunc(values, v.MatchString)
 			if !valueExists {
 				return false
 			}

--- a/go-mux/mux_test.go
+++ b/go-mux/mux_test.go
@@ -9,7 +9,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"net/http"
 	"net/url"
 	"reflect"
@@ -2775,7 +2776,7 @@ func TestSubrouterCustomMethodNotAllowed(t *testing.T) {
 				tt.Errorf("Expected status code 405 (got %d)", w.Code)
 			}
 
-			b, err := ioutil.ReadAll(w.Body)
+			b, err := io.ReadAll(w.Body)
 			if err != nil {
 				tt.Errorf("failed to read body: %v", err)
 			}

--- a/go-mux/regexp.go
+++ b/go-mux/regexp.go
@@ -195,7 +195,7 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 
 // url builds a URL part using the given values.
 func (r *routeRegexp) url(values map[string]string) (string, error) {
-	urlValues := make([]interface{}, len(r.varsN), len(r.varsN))
+	urlValues := make([]any, len(r.varsN), len(r.varsN))
 	for k, v := range r.varsN {
 		value, ok := values[v]
 		if !ok {


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)